### PR TITLE
Escape single quote in value.

### DIFF
--- a/influx/influx.go
+++ b/influx/influx.go
@@ -58,7 +58,7 @@ func (s Series) fetchQuery(timeFilter string) string {
 		f.WriteString(" where")
 	}
 	for i, pair := range s.LabelPairs {
-		fmt.Fprintf(f, " %q='%s'", pair.Name, pair.Value)
+		fmt.Fprintf(f, " %q='%s'", pair.Name, strings.ReplaceAll(pair.Value, "'", "\\'"))
 		if i != len(s.LabelPairs)-1 {
 			f.WriteString(" and")
 		}


### PR DESCRIPTION
I have single quotes in some of my label values in influx which causes the migration to crash.
This may not be the correct way to fix this, but hopefully it proves useful in fixing this bug.