### PR TITLE
importer: rename `vm-decimal-places` flag to `vm-significant-figures`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Please note, that vmctl performs initial readiness check for the given address b
    --vm-concurrency value                      Number of workers concurrently performing import requests to VM (default: 2)
    --vm-compress                               Whether to apply gzip compression to import requests (default: true)
    --vm-batch-size value                       How many samples importer collects before sending the import request to VM (default: 200000)
-   --vm-decimal-places value                   The number of significant decimal places to leave in metric values before importing. 
+   --vm-significant-figures value              The number of significant figures to leave in metric values before importing. 
 See https://en.wikipedia.org/wiki/Significant_figures. Zero value saves all the significant decimal places. 
 This option may be used for increasing on-disk compression level for the stored metrics (default: 0)
    --help, -h                                  show help (default: false)
@@ -192,7 +192,7 @@ Please note, that vmctl performs initial readiness check for the given address b
    --vm-concurrency value           Number of workers concurrently performing import requests to VM (default: 2)
    --vm-compress                    Whether to apply gzip compression to import requests (default: true)
    --vm-batch-size value            How many samples importer collects before sending the import request to VM (default: 200000)
-   --vm-decimal-places value                   The number of significant decimal places to leave in metric values before importing. 
+   --vm-significant-figures value   The number of significant figures to leave in metric values before importing. 
 See https://en.wikipedia.org/wiki/Significant_figures. Zero value saves all the significant decimal places. 
 This option may be used for increasing on-disk compression level for the stored metrics (default: 0)
    --help, -h                       show help (default: false)
@@ -400,18 +400,18 @@ behavior and no user interaction required - pass `-s` flag to enable "silence" m
     -s Whether to run in silent mode. If set to true no confirmation prompts will appear. (default: false)
 ```
 
-### Decimal places
+### Significant figures
 
-`vmctl` allows to limit the number of [significant decimal places](https://en.wikipedia.org/wiki/Significant_figures)
-before importing. For example, average value for response size is `102.342305` bytes and it has 9 significant figures.
-If you ask a human to pronounce this value then with high probability value will be rounded to first 4 or 5 significant 
-figures because the rest aren't really that important to mention. In most of cases, such high precision is too much. 
+`vmctl` allows to limit the number of [significant figures](https://en.wikipedia.org/wiki/Significant_figures)
+before importing. For example, the average value for response size is `102.342305` bytes and it has 9 significant figures.
+If you ask a human to pronounce this value then with high probability value will be rounded to first 4 or 5 figures 
+because the rest aren't really that important to mention. In most cases, such a high precision is too much. 
 Moreover, such values may be just a result of [floating point arithmetic](https://en.wikipedia.org/wiki/Floating-point_arithmetic), 
 create a [false precision](https://en.wikipedia.org/wiki/False_precision) and result into bad compression ratio 
 according to [information theory](https://en.wikipedia.org/wiki/Information_theory). 
 
-The `--vm-decimal-places` flag allows to limit the number of significant figures. It takes no effect if set to 0 (by default),
-but set `--vm-decimal-places=5` and `102.342305` will be rounded to `102.34`. Such value will have much higher compression
-ratio comparing to previous one and will save some extra disk space after migration. The most common case for using
-this flag is to reduce number of significant figures for timeseries storing aggregation results such as `average`,
-`rate`, etc.   
+The `--vm-significant-figures` flag allows to limit the number of significant figures. It takes no effect if set 
+to 0 (by default), but set `--vm-significant-figures=5` and `102.342305` will be rounded to `102.34`. Such value will 
+have much higher compression ratio comparing to previous one and will save some extra disk space after the migration. 
+The most common case for using this flag is to reduce number of significant figures for time series storing aggregation 
+results such as `average`, `rate`, etc.   

--- a/flags.go
+++ b/flags.go
@@ -20,14 +20,14 @@ var (
 )
 
 const (
-	vmAddr          = "vm-addr"
-	vmUser          = "vm-user"
-	vmPassword      = "vm-password"
-	vmAccountID     = "vm-account-id"
-	vmConcurrency   = "vm-concurrency"
-	vmCompress      = "vm-compress"
-	vmBatchSize     = "vm-batch-size"
-	vmDecimalPlaces = "vm-decimal-places"
+	vmAddr               = "vm-addr"
+	vmUser               = "vm-user"
+	vmPassword           = "vm-password"
+	vmAccountID          = "vm-account-id"
+	vmConcurrency        = "vm-concurrency"
+	vmCompress           = "vm-compress"
+	vmBatchSize          = "vm-batch-size"
+	vmSignificantFigures = "vm-significant-figures"
 )
 
 var (
@@ -70,10 +70,10 @@ var (
 			Usage: "How many samples importer collects before sending the import request to VM",
 		},
 		&cli.IntFlag{
-			Name:  vmDecimalPlaces,
+			Name:  vmSignificantFigures,
 			Value: 0,
-			Usage: "The number of significant decimal places to leave in metric values before importing. " +
-				"See https://en.wikipedia.org/wiki/Significant_figures. Zero value saves all the significant decimal places. " +
+			Usage: "The number of significant figures to leave in metric values before importing. " +
+				"See https://en.wikipedia.org/wiki/Significant_figures. Zero value saves all the significant figures. " +
 				"This option may be used for increasing on-disk compression level for the stored metrics",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -117,13 +117,13 @@ func main() {
 
 func initConfigVM(c *cli.Context) vm.Config {
 	return vm.Config{
-		Addr:          c.String(vmAddr),
-		User:          c.String(vmUser),
-		Password:      c.String(vmPassword),
-		Concurrency:   uint8(c.Int(vmConcurrency)),
-		Compress:      c.Bool(vmCompress),
-		AccountID:     c.Int(vmAccountID),
-		BatchSize:     c.Int(vmBatchSize),
-		DecimalPlaces: c.Int(vmDecimalPlaces),
+		Addr:               c.String(vmAddr),
+		User:               c.String(vmUser),
+		Password:           c.String(vmPassword),
+		Concurrency:        uint8(c.Int(vmConcurrency)),
+		Compress:           c.Bool(vmCompress),
+		AccountID:          c.Int(vmAccountID),
+		BatchSize:          c.Int(vmBatchSize),
+		SignificantFigures: c.Int(vmSignificantFigures),
 	}
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -38,10 +38,10 @@ type Config struct {
 	User string
 	// Password for basic auth
 	Password string
-	// DecimalPlaces defines the number of significant decimal places to leave
+	// SignificantFigures defines the number of significant figures to leave
 	// in metric values before importing.
 	// Zero value saves all the significant decimal places
-	DecimalPlaces int
+	SignificantFigures int
 }
 
 // Importer performs insertion of timeseries
@@ -111,7 +111,7 @@ func NewImporter(cfg Config) (*Importer, error) {
 	for i := 0; i < int(cfg.Concurrency); i++ {
 		go func() {
 			defer im.wg.Done()
-			im.startWorker(cfg.BatchSize, cfg.DecimalPlaces)
+			im.startWorker(cfg.BatchSize, cfg.SignificantFigures)
 		}()
 	}
 	im.ResetStats()
@@ -145,7 +145,7 @@ func (im *Importer) Close() {
 	})
 }
 
-func (im *Importer) startWorker(batchSize, decimalPlaces int) {
+func (im *Importer) startWorker(batchSize, significantFigures int) {
 	var batch []*TimeSeries
 	var dataPoints int
 	var waitForBatch time.Time
@@ -166,10 +166,10 @@ func (im *Importer) startWorker(batchSize, decimalPlaces int) {
 				waitForBatch = time.Now()
 			}
 
-			if decimalPlaces > 0 {
-				// Round values according to decimalPlaces
+			if significantFigures > 0 {
+				// Round values according to significantFigures
 				for i, v := range ts.Values {
-					ts.Values[i] = decimal.Round(v, decimalPlaces)
+					ts.Values[i] = decimal.Round(v, significantFigures)
 				}
 			}
 


### PR DESCRIPTION
The previous notion was inconsistent with what `decimal.Round` does.
According to [wiki](https://en.wikipedia.org/wiki/Significant_figures) rounding
applied to all significant figures, not just decimal ones.