### PR TITLE
Support string values for `vm-account-id` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Should be the same as --httpListenAddr value for single-node version or VMInsert
 Please note, that vmctl performs initial readiness check for the given address by checking `/health` endpoint. (default: "http://localhost:8428")
    --vm-user value                             VictoriaMetrics username for basic auth [$VM_USERNAME]
    --vm-password value                         VictoriaMetrics password for basic auth [$VM_PASSWORD]
-   --vm-account-id value                       Account(tenant) ID - is required for cluster VM. (default: -1)
+   --vm-account-id value                       AccountID is an arbitrary 32-bit integer identifying namespace for data ingestion (aka tenant). 
+It is possible to set it as accountID:projectID, where projectID is also arbitrary 32-bit integer. 
+If projectID isn't set, then it equals to 0
    --vm-concurrency value                      Number of workers concurrently performing import requests to VM (default: 2)
    --vm-compress                               Whether to apply gzip compression to import requests (default: true)
    --vm-batch-size value                       How many samples importer collects before sending the import request to VM (default: 200000)
@@ -194,7 +196,9 @@ Should be the same as --httpListenAddr value for single-node version or VMInsert
 Please note, that vmctl performs initial readiness check for the given address by checking `/health` endpoint. (default: "http://localhost:8428")
    --vm-user value                  VictoriaMetrics username for basic auth [$VM_USERNAME]
    --vm-password value              VictoriaMetrics password for basic auth [$VM_PASSWORD]
-   --vm-account-id value            Account(tenant) ID - is required for cluster VM. (default: -1)
+   --vm-account-id value                       AccountID is an arbitrary 32-bit integer identifying namespace for data ingestion (aka tenant). 
+It is possible to set it as accountID:projectID, where projectID is also arbitrary 32-bit integer. 
+If projectID isn't set, then it equals to 0
    --vm-concurrency value           Number of workers concurrently performing import requests to VM (default: 2)
    --vm-compress                    Whether to apply gzip compression to import requests (default: true)
    --vm-batch-size value            How many samples importer collects before sending the import request to VM (default: 200000)

--- a/flags.go
+++ b/flags.go
@@ -49,10 +49,11 @@ var (
 			Usage:   "VictoriaMetrics password for basic auth",
 			EnvVars: []string{"VM_PASSWORD"},
 		},
-		&cli.IntFlag{
-			Name:  vmAccountID,
-			Value: -1,
-			Usage: "Account(tenant) ID - is required for cluster VM.",
+		&cli.StringFlag{
+			Name: vmAccountID,
+			Usage: "AccountID is an arbitrary 32-bit integer identifying namespace for data ingestion (aka tenant). \n" +
+				"It is possible to set it as accountID:projectID, where projectID is also arbitrary 32-bit integer. \n" +
+				"If projectID isn't set, then it equals to 0",
 		},
 		&cli.UintFlag{
 			Name:  vmConcurrency,

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func initConfigVM(c *cli.Context) vm.Config {
 		Password:           c.String(vmPassword),
 		Concurrency:        uint8(c.Int(vmConcurrency)),
 		Compress:           c.Bool(vmCompress),
-		AccountID:          c.Int(vmAccountID),
+		AccountID:          c.String(vmAccountID),
 		BatchSize:          c.Int(vmBatchSize),
 		SignificantFigures: c.Int(vmSignificantFigures),
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -28,9 +28,9 @@ type Config struct {
 	Concurrency uint8
 	// Whether to apply gzip compression
 	Compress bool
-	// AccountID for cluster version
-	// Less than 0 assumes single node version
-	AccountID int
+	// AccountID for cluster version.
+	// Empty value assumes it is a single node version
+	AccountID string
 	// BatchSize defines how many samples
 	// importer collects before sending the import request
 	BatchSize int
@@ -83,10 +83,10 @@ func NewImporter(cfg Config) (*Importer, error) {
 	// if single version
 	// see https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master#how-to-import-time-series-data
 	importPath := addr + "/api/v1/import"
-	if cfg.AccountID != -1 {
+	if cfg.AccountID != "" {
 		// if cluster version
 		// see https://github.com/VictoriaMetrics/VictoriaMetrics/tree/cluster#url-format
-		importPath = fmt.Sprintf("%s/insert/%d/prometheus/api/v1/import", addr, uint32(cfg.AccountID))
+		importPath = fmt.Sprintf("%s/insert/%s/prometheus/api/v1/import", addr, cfg.AccountID)
 	}
 
 	im := &Importer{


### PR DESCRIPTION
Value for accountID could contain a projectID in format
`accountID:projectID`. The change allows to set arbitrary
string value to `vm-account-id` flag in case if user wants
to specify projectID.

Address #26 