### PR TITLE
Convert json.Number from InfluxDB correctly

### DIFF
--- a/influx/parser.go
+++ b/influx/parser.go
@@ -1,6 +1,7 @@
 package influx
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -37,6 +38,8 @@ func parseResult(r influx.Result) ([]queryValues, error) {
 
 func toFloat64(v interface{}) (float64, error) {
 	switch i := v.(type) {
+	case json.Number:
+		return i.Float64()
 	case float64:
 		return i, nil
 	case float32:


### PR DESCRIPTION
I was having an issue with importing InfluxDB from my v1.8 db, running `vmctl influx --influx-database home_assistant` as the cmd.

This is my first attempt at Go, so please correct me if I'm doing something incorrect (like the type assertion).

Initial error:
```
InfluxDB import mode
2020/09/28 12:50:05 Exploring scheme for database "home_assistant"
2020/09/28 12:50:05 fetching fields: command: "show field keys"; database: "home_assistant"; retention: "autogen"
2020/09/28 12:50:05 found 2163 fields; skipped 1739 non-numeric fields
2020/09/28 12:50:05 fetching series: command: "show series"; database: "home_assistant"; retention: "autogen"
2020/09/28 12:50:05 found 681 series
Found 4652 timeseries to import. Continue? [Y/n]
2020/09/28 12:50:06 influx error: request failed for " "."avg_price": failed to convert value "avg_price".0 to float64: unexpected value type 0.165
```
With some debugging:
```
fieldValues = [0.165 0.165 0.165 0.165 0.165 0.165]
fv = 0.165
fv type: json.Number
(cr.field, value) = avg_price 0
Types: (cr.field, value) = (string, float64)
2020/09/28 12:50:06 influx error: request failed for " "."avg_price": failed to convert value "avg_price".0 to float64: unexpected value type 0.165
```
After fix:
```
2020/09/28 13:41:57 Import finished!
2020/09/28 13:41:57 VictoriaMetrics importer stats:
  idle duration: 12m34.584399278s;
  time spent while importing: 7m0.722422943s;
  total samples: 90289930;
  samples/s: 214606.89;
  total bytes: 1.8 GB;
  bytes/s: 4.4 MB;
  import requests: 448;
  import requests retries: 0;
2020/09/28 13:41:57 Total time: 7m2.017933135s
```